### PR TITLE
Feature/sensor filtering

### DIFF
--- a/AtmosphericSensorNode.py
+++ b/AtmosphericSensorNode.py
@@ -4,7 +4,11 @@ from lib.inboxidau.rolling_appender_log import LogLevel
 
 class AtmosphericSensorNode(UPicoWSensorNode):
 
-    # noqa: E501 # Used to delay restarting main() on an unhandled exception STATIC_NODE_RESTART_DELAY = 60
+    # noqa: E501 # Used to delay restarting main() on an unhandled exception
+    STATIC_NODE_RESTART_DELAY = 60
+    
+    # Used to designate the delay in seconds between sensor reading
+    STATIC_NODE_SENSE_REPEAT_DELAY = 60    
 
     # noqa: E501 Used to designate the log level required, normally LogLevel.INFO will suffice for a completed device
     STATIC_NODE_LOG_LEVEL = LogLevel.INFO

--- a/DistanceSensorNode.py
+++ b/DistanceSensorNode.py
@@ -15,6 +15,8 @@ class DistanceSensorNode(UPicoWSensorNode):
     # before submitting in the post method.
     STATIC_NODE_SENSE_FILTER_SIZE = 10
 
+    STATIC_NODE_OCCUPANCY_HISTORY_SIZE = 3
+
     POST_SENSOR_DATA_FORMAT = "{}.post_sensor_data() {} to >{}"
 
     def __init__(self, log, config_path='UPicoWSensorNode.json'):
@@ -43,6 +45,11 @@ class DistanceSensorNode(UPicoWSensorNode):
 
         from lib.inboxidau.sensor_reading_filter import DiscardExtremesFilter
         self.filtered_distance_sensor = DiscardExtremesFilter(self.STATIC_NODE_SENSE_FILTER_SIZE)
+
+        self.occupancy_history = []  # Stores the last few occupancy assessments
+        self.sensor_data["occupancy"] = False
+        self.sensor_data["distance"] = 0
+        self.last_removed_occupancy = None  # Tracks the last removed occupancy state
 
     def post_sensor_data(self):
         try:
@@ -77,6 +84,46 @@ class DistanceSensorNode(UPicoWSensorNode):
                 LogLevel.ERROR)
         return None
 
+    def update_occupancy_history(self, occupancy):
+        # Updates the occupancy history with the latest assessment.
+        # Save the last removed occupancy state before removing it.
+        if len(self.occupancy_history) >= self.STATIC_NODE_OCCUPANCY_HISTORY_SIZE:
+            self.last_removed_occupancy = self.occupancy_history.pop(0)
+        self.occupancy_history.append(occupancy)
+
+    def detect_occupancy_change(self):
+        # Detects if there's a change in occupancy based on the last few assessments.
+        if len(self.occupancy_history) < self.STATIC_NODE_OCCUPANCY_HISTORY_SIZE:
+            self.log_message("Not enough data to assess a change in occupancy ", LogLevel.DEBUG)
+            return False  # Not enough data to assess a change
+
+        # Check if the last removed value is None
+        if self.last_removed_occupancy is None:
+            self.log_message("Not enough data popped to assess a change in occupancy ", LogLevel.DEBUG)
+            return False  # Not enough change to assess a change
+
+        # Check if all recent assessments are the same
+        last_state = self.occupancy_history[-1]
+        if not all(state == last_state for state in self.occupancy_history):
+            self.log_message("No persistent change in historic occupancy", LogLevel.DEBUG)
+            return False  # No change in occupancy
+
+        # Check that the last popped value is not the same as the persistent value
+        if self.last_removed_occupancy is not None and self.last_removed_occupancy == last_state:
+            self.log_message("No change in historic occupancy", LogLevel.DEBUG)
+            return False  # No change in occupancy
+
+        # Otherwise, there has been a change
+        self.log_message(f"There was a change in historic occupancy last_state:{last_state}  last_removed:{self.last_removed_occupancy}",  # noqa: E501
+                         LogLevel.DEBUG)
+        for index, item in enumerate(self.occupancy_history):
+            print(f"Index {index}: {item}")
+
+        return True
+
+    def assess_occupancy(self, filtered_value):
+        return filtered_value < self.OCCUPANCY_DISTANCE  # noqa: E501  True if occupied, False if not
+
     def read_sensor_data(self):
         try:
             self.log_message("read_sensor_data ", LogLevel.DEBUG)
@@ -91,12 +138,19 @@ class DistanceSensorNode(UPicoWSensorNode):
                     f"{str(_)}: {str(self.sensor_data['distance'])} mm (last raw value: {str(distance)} mm)",
                     LogLevel.DEBUG)
 
-            # if object detected within nominated distance
-            self.sensor_data["occupancy"] = self.sensor_data["distance"] <= self.OCCUPANCY_DISTANCE  # noqa: E501
-            if self.sensor_data["occupancy"] is True:
-                self.log.log_message("Occupied", LogLevel.INFO)
-            else:
-                self.log.log_message("Vacant", LogLevel.INFO)
+            # Add the current occupancy assessment to the history
+            occupancy_state = self.assess_occupancy(distance)
+            self.update_occupancy_history(occupancy_state)
+            self.log.log_message(f"{distance} {occupancy_state}", LogLevel.DEBUG)
+
+            # Detect if there has been a consistent change in status according to history
+            if self.detect_occupancy_change() is True:
+                # if object detected within nominated distance
+                self.sensor_data["occupancy"] = occupancy_state
+                if self.sensor_data["occupancy"] is True:
+                    self.log.log_message("Occupied", LogLevel.INFO)
+                else:
+                    self.log.log_message("Vacant", LogLevel.INFO)
 
         except Exception as e:
             self.log_message(

--- a/SAMPLE Occupancy main.py
+++ b/SAMPLE Occupancy main.py
@@ -1,9 +1,10 @@
 from lib.inboxidau.rolling_appender_log import URollingAppenderLog, LogLevel
-from lib.inboxidau.pico_w_sensor_node import UPicoWSensorNode
 import time
 from DistanceSensorNode import DistanceSensorNode
 
-log = URollingAppenderLog("DistanceSensorNode.log", max_file_size_bytes=1024, max_backups=10, print_messages=True, log_level=DistanceSensorNode.STATIC_NODE_LOG_LEVEL)
+log = URollingAppenderLog("DistanceSensorNode.log", max_file_size_bytes=4096,
+                          max_backups=10, print_messages=True,
+                          log_level=DistanceSensorNode.STATIC_NODE_LOG_LEVEL)
 
 myNode = DistanceSensorNode(log=log, config_path="config.json")
 
@@ -15,7 +16,7 @@ while True:
     except Exception as e:
         print(f"CONSOLE: exception in myNode ({e})")
         log.log_message(f"main.py {str(e)}", LogLevel.ERROR)
-        
+
     print(f"CONSOLE: retry in {myNode.STATIC_NODE_RESTART_DELAY}.")
     log.log_message(f"main.py retry in {myNode.STATIC_NODE_RESTART_DELAY} seconds.", LogLevel.INFO)
     time.sleep(myNode.STATIC_NODE_RESTART_DELAY)

--- a/lib/inboxidau/sensor_reading_filter.py
+++ b/lib/inboxidau/sensor_reading_filter.py
@@ -1,0 +1,71 @@
+class DiscardExtremesFilter:
+
+    # Discard Extremes
+    # How it works: Remove just the highest and lowest readings in a window
+    # of recent data points, then calculate the average of the remaining readings.
+    # Implementation: Keep a sliding window of the last n readings, remove the
+    # maximum and minimum, and calculate the mean of what's left.
+
+    # Usage:
+    # filter = DiscardExtremesFilter(window_size=5)
+    # filtered_value = filter.add_reading(sensor_value)
+
+    def __init__(self, window_size=5):
+        self.window = []
+        self.window_size = window_size
+
+    def reset(self):
+        # Resets the filter to its initial empty state.
+        self.window = []
+
+    def add_reading(self, value):
+        if len(self.window) >= self.window_size:
+            self.window.pop(0)
+        self.window.append(value)
+
+        if len(self.window) > 2:  # Ensure we have enough data to discard
+            sorted_window = sorted(self.window)
+            # Remove highest and lowest, then calculate mean
+            trimmed_window = sorted_window[1:-1]
+            return sum(trimmed_window) / len(trimmed_window)
+        return value  # Return the value directly if not enough data
+
+
+class TrimmedMeanFilter:
+
+    # Trimmed Mean
+    # How it works: A trimmed mean discards a certain percentage of the
+    # highest and lowest values before calculating the mean of the remaining
+    # values.
+
+    # Implementation: You sort the readings, remove the top p% and bottom p%
+    # of values, and then compute the average of the remaining values.
+
+    # Usage:
+    # filter = TrimmedMeanFilter(window_size=5, trim_percent=0.1)
+    # filtered_value = filter.add_reading(sensor_value)
+
+    def __init__(self, window_size=5, trim_percent=0.1):
+        self.window = []
+        self.window_size = window_size
+        self.trim_percent = trim_percent
+
+    def reset(self):
+        # Resets the filter to its initial empty state.
+        self.window = []
+
+    def add_reading(self, value):
+        # Maintain window of fixed size
+        if len(self.window) >= self.window_size:
+            self.window.pop(0)
+        self.window.append(value)
+
+        # Calculate trimmed mean if enough data
+        if len(self.window) > 1:
+            sorted_window = sorted(self.window)
+            trim_count = int(len(sorted_window) * self.trim_percent)
+            trimmed_window = sorted_window[trim_count:-trim_count] if trim_count else sorted_window
+            return sum(trimmed_window) / len(trimmed_window)
+
+        # Return value directly if not enough data
+        return value

--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 from lib.inboxidau.rolling_appender_log import URollingAppenderLog, LogLevel
-from lib.inboxidau.pico_w_sensor_node import UPicoWSensorNode
+
 import time
 from AtmosphericSensorNode import AtmosphericSensorNode
 
-log = URollingAppenderLog("AtmosphericSensorNode.log", max_file_size_bytes=1024, max_backups=10, print_messages=True, log_level=AtmosphericSensorNode.STATIC_NODE_LOG_LEVEL)
+log = URollingAppenderLog("AtmosphericSensorNode.log", max_file_size_bytes=1024,
+                          max_backups=10, print_messages=True,
+                          log_level=AtmosphericSensorNode.STATIC_NODE_LOG_LEVEL)
 
 myNode = AtmosphericSensorNode(log=log, config_path="config.json")
 
@@ -15,7 +17,7 @@ while True:
     except Exception as e:
         print(f"CONSOLE: exception in myNode ({e})")
         log.log_message(f"main.py {str(e)}", LogLevel.ERROR)
-        
+
     print(f"CONSOLE: retry in {myNode.STATIC_NODE_RESTART_DELAY}.")
     log.log_message(f"main.py retry in {myNode.STATIC_NODE_RESTART_DELAY} seconds.", LogLevel.INFO)
     time.sleep(myNode.STATIC_NODE_RESTART_DELAY)


### PR DESCRIPTION
Added a facility to take a number of sensor readings per cycle and use two different simple filters to discard extreme values and return a mean reading.

The mean reading is retained for a nominated number of readings and the reading must be consistent over that number of readings to be used to trigger a status change.

This was included because I was getting spurious poor readings which were causing occupancy to quickly alternate between True and False. In reality, I wanted occupancy to indicate a longer-term presence than the sensor read cycle.